### PR TITLE
修复题目正确率分析SQL语法错误的问题

### DIFF
--- a/src/main/resources/mapper/ExamQuAnswerMapper.xml
+++ b/src/main/resources/mapper/ExamQuAnswerMapper.xml
@@ -12,7 +12,7 @@
 
     <!-- 获取单题作答信息 -->
     <select id="questionAnalyse" resultType="cn.org.alan.exam.model.vo.score.QuestionAnalyseVO">
-        select count(case where is_right = 1 then 1 end) as rightCount, count(*) as totalCount
+        select count(case when is_right = 1 then 1 end) as rightCount, count(*) as totalCount
         from t_exam_qu_answer
         where exam_id = #{examId}
         and question_id = #{questionId}


### PR DESCRIPTION
### 问题
`ExamQuAnswerMapper.xml` 的 `questionAnalyse` 写成 `count(case where ...)`，应为 `CASE WHEN`，教师端调用该接口必然抛 `BadSqlGrammarException`，功能完全不可用。

### 修复
修正为 `case when`